### PR TITLE
feat: relaxing react-redux connect definition

### DIFF
--- a/lib/isReactReduxConnect.js
+++ b/lib/isReactReduxConnect.js
@@ -1,8 +1,5 @@
 module.exports = function (node) {
   return (
     node.callee.name === 'connect'
-    && node.parent
-    && node.parent.type === 'CallExpression'
-    && node.parent.arguments.length === 1
   );
 };


### PR DESCRIPTION
closes #22. Relaxing the definition of `connect` to pickup any function call named `connect`. This may lead to false positive if there  are some other functions called `connect` throughout the code. Hopefully for the codebase that uses react-redux and has this plugin on this should rather be an exception to have a random `connect` function call.

 