### PR TITLE
FIX: Error message reports wrong argument number

### DIFF
--- a/lib/rules/connect-prefer-named-arguments.js
+++ b/lib/rules/connect-prefer-named-arguments.js
@@ -9,7 +9,7 @@ const argumentNames = [
 
 const report = function (context, node, i) {
   context.report({
-    message: `Connect function argument #${i} should be named ${argumentNames[i]}`,
+    message: `Connect function argument #${i + 1} should be named ${argumentNames[i]}`,
     node,
   });
 };


### PR DESCRIPTION
RE: 
> Connect function argument #1 should be named mapDispatchToProps

I found this error message misleading since normally one does not refer to argument numbers as though they were zero-indexed. So I've just fixed the off-by-one error in the report function.