### PR TITLE
 feat: no-unused-prop-types

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const rules = {
   'mapStateToProps-no-store': require('./lib/rules/mapStateToProps-no-store'),
   'mapStateToProps-prefer-hoisted': require('./lib/rules/mapStateToProps-prefer-hoisted'),
   'mapStateToProps-prefer-parameters-names': require('./lib/rules/mapStateToProps-prefer-parameters-names'),
+  'no-unused-prop-types': require('./lib/rules/no-unused-prop-types'),
   'prefer-separate-component-file': require('./lib/rules/prefer-separate-component-file'),
 };
 
@@ -34,6 +35,7 @@ module.exports = {
         'react-redux/mapStateToProps-no-store': 2,
         'react-redux/mapStateToProps-prefer-hoisted': 2,
         'react-redux/mapStateToProps-prefer-parameters-names': 2,
+        'react-redux/no-unused-prop-types': 2,
         'react-redux/prefer-separate-component-file': 1,
       },
     },

--- a/lib/filterReports.js
+++ b/lib/filterReports.js
@@ -1,0 +1,162 @@
+const ruleComposer = require('eslint-rule-composer');
+
+/* eslint-disable */
+
+// ---- Start copy ---- //
+// from https://github.com/not-an-aardvark/eslint-rule-composer/blob/master/lib/rule-composer.js#L3-L125
+
+/**
+ * Translates a multi-argument context.report() call into a single object argument call
+ * @param {...*} arguments A list of arguments passed to `context.report`
+ * @returns {MessageDescriptor} A normalized object containing report information
+ */
+function normalizeMultiArgReportCall() {
+  // If there is one argument, it is considered to be a new-style call already.
+  if (arguments.length === 1) {
+    return arguments[0];
+  }
+
+  // If the second argument is a string, the arguments are interpreted as [node, message, data, fix].
+  if (typeof arguments[1] === 'string') {
+    return {
+      node: arguments[0],
+      message: arguments[1],
+      data: arguments[2],
+      fix: arguments[3],
+    };
+  }
+
+  // Otherwise, the arguments are interpreted as [node, loc, message, data, fix].
+  return {
+    node: arguments[0],
+    loc: arguments[1],
+    message: arguments[2],
+    data: arguments[3],
+    fix: arguments[4],
+  };
+}
+
+/**
+ * Normalizes a MessageDescriptor to always have a `loc` with `start` and `end` properties
+ * @param {MessageDescriptor} descriptor A descriptor for the report from a rule.
+ * @returns {{start: Location, end: (Location|null)}} An updated location that infers the `start` and `end` properties
+ * from the `node` of the original descriptor, or infers the `start` from the `loc` of the original descriptor.
+ */
+function normalizeReportLoc(descriptor) {
+  if (descriptor.loc) {
+    if (descriptor.loc.start) {
+      return descriptor.loc;
+    }
+    return { start: descriptor.loc, end: null };
+  }
+  return descriptor.node.loc;
+}
+
+
+/**
+ * Interpolates data placeholders in report messages
+ * @param {MessageDescriptor} descriptor The report message descriptor.
+ * @param {Object} messageIds Message IDs from rule metadata
+ * @returns {{message: string, data: Object}} The interpolated message and data for the descriptor
+ */
+function normalizeMessagePlaceholders(descriptor, messageIds) {
+  const message = typeof descriptor.messageId === 'string' ? messageIds[descriptor.messageId] : descriptor.message;
+  if (!descriptor.data) {
+    return {
+      message,
+      data: typeof descriptor.messageId === 'string' ? {} : null,
+    };
+  }
+
+  const normalizedData = Object.create(null);
+  const interpolatedMessage = message.replace(/\{\{\s*([^{}]+?)\s*\}\}/g, (fullMatch, term) => {
+    if (term in descriptor.data) {
+      normalizedData[term] = descriptor.data[term];
+      return descriptor.data[term];
+    }
+
+    return fullMatch;
+  });
+
+  return {
+    message: interpolatedMessage,
+    data: Object.freeze(normalizedData),
+  };
+}
+
+function getRuleMeta(rule) {
+  return typeof rule === 'object' && rule.meta && typeof rule.meta === 'object'
+    ? rule.meta
+    : {};
+}
+
+function getMessageIds(rule) {
+  const meta = getRuleMeta(rule);
+  return meta.messages && typeof rule.meta.messages === 'object'
+    ? meta.messages
+    : {};
+}
+
+function getReportNormalizer(rule) {
+  const messageIds = getMessageIds(rule);
+
+  return function normalizeReport() {
+    const descriptor = normalizeMultiArgReportCall(...arguments);
+    const interpolatedMessageAndData = normalizeMessagePlaceholders(descriptor, messageIds);
+
+    return {
+      node: descriptor.node,
+      message: interpolatedMessageAndData.message,
+      messageId: typeof descriptor.messageId === 'string' ? descriptor.messageId : null,
+      data: typeof descriptor.messageId === 'string' ? interpolatedMessageAndData.data : null,
+      loc: normalizeReportLoc(descriptor),
+      fix: descriptor.fix,
+    };
+  };
+}
+
+function getRuleCreateFunc(rule) {
+  return typeof rule === 'function' ? rule : rule.create;
+}
+
+function removeMessageIfMessageIdPresent(reportDescriptor) {
+  const newDescriptor = Object.assign({}, reportDescriptor);
+
+  if (typeof reportDescriptor.messageId === 'string' && typeof reportDescriptor.message === 'string') {
+    delete newDescriptor.message;
+  }
+
+  return newDescriptor;
+}
+
+// ---- End copy ---- //
+
+const filterReports = (rule, filterNode, filterAll) => Object.freeze({
+  create(context) {
+    const removeNodesFromReport = [];
+    let allNodesFiltered = false;
+    return getRuleCreateFunc(rule)(Object.freeze(Object.create(
+      context,
+      {
+        report: {
+          enumerable: true,
+          value() {
+            const reportDescriptor = getReportNormalizer(rule)(...arguments);
+            if (filterAll(reportDescriptor)) {
+              allNodesFiltered = true;
+            }
+            if (filterNode(reportDescriptor)) {
+              removeNodesFromReport.push(reportDescriptor.node);
+            } else if (!allNodesFiltered && !removeNodesFromReport.includes(reportDescriptor.node)) {
+              context.report(removeMessageIfMessageIdPresent(reportDescriptor));
+            }
+          },
+        },
+      },
+    )));
+  },
+  schema: rule.schema,
+  meta: getRuleMeta(rule),
+});
+
+module.exports = (rules, filterNode, filterAll) => filterReports(ruleComposer.joinReports(rules), filterNode, filterAll);

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -1,0 +1,61 @@
+const filterReports = require('../filterReports');
+const isReactReduxConnect = require('../isReactReduxConnect');
+
+const filterAllMessage = 'Filter report for all props since mapStateToProps has second argument';
+const filterNodeMessage = 'TBD: selectively filter error for nodes';
+
+const noUnusedPropTypesReact = require('eslint-plugin-react').rules['no-unused-prop-types'];
+
+const propsUsedInRedux = function (context) {
+  return {
+    VariableDeclaration(node) {
+      node.declarations.forEach((decl) => {
+        const name = decl.id && decl.id.name;
+        if (name === 'mapStateToProps' || name === 'mapDispatchToProps') {
+          const hasSecondArgument = decl.init.params && decl.init.params[1];
+          if (hasSecondArgument) {
+            context.report(node, filterAllMessage);
+          }
+        }
+      });
+    },
+    FunctionDeclaration(node) {
+      const name = node.id && node.id.name;
+      if (name === 'mapStateToProps' || name === 'mapDispatchToProps') {
+        const hasSecondArgument = node.params && node.params[1];
+        if (hasSecondArgument) {
+          context.report(node, filterAllMessage);
+        }
+      }
+    },
+    CallExpression(node) {
+      if (isReactReduxConnect(node)) {
+        const mapStateToProps = node.arguments && node.arguments[0];
+        const mapDispatchToProps = node.arguments && node.arguments[1];
+        if (mapStateToProps && mapStateToProps.body) {
+          const hasSecondArgument = mapStateToProps.params && mapStateToProps.params[1];
+          if (hasSecondArgument) {
+            context.report(node, filterAllMessage);
+          }
+        }
+        if (mapDispatchToProps && mapDispatchToProps.body) {
+          const hasSecondArgument = mapDispatchToProps.params && mapDispatchToProps.params[1];
+          if (hasSecondArgument) {
+            context.report(node, filterAllMessage);
+          }
+        }
+      }
+    },
+  };
+};
+
+const filterNode = report =>
+  report.message === filterNodeMessage;
+
+const filterAll = report =>
+  report.message === filterAllMessage;
+
+module.exports = filterReports([
+  propsUsedInRedux,
+  noUnusedPropTypesReact,
+], filterNode, filterAll);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-node": "^5.2.1",
     "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-react": "^7.5.1",
     "eslint-plugin-standard": "^3.0.1",
     "husky": "^0.14.3",
     "mocha": "^4.0.1",
@@ -43,5 +42,9 @@
   "license": "ISC",
   "directories": {
     "test": "tests"
+  },
+  "dependencies": {
+    "eslint-rule-composer": "^0.3.0",
+    "eslint-plugin-react": "^7.11.1"
   }
 }

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1,0 +1,59 @@
+require('babel-eslint');
+
+const rule = require('../../../lib/rules/no-unused-prop-types');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 6,
+  sourceType: 'module',
+  ecmaFeatures: {
+    experimentalObjectRestSpread: true,
+    jsx: true,
+  },
+};
+
+
+const ruleTester = new RuleTester({ parserOptions });
+
+ruleTester.run('no-unused-prop-types', rule, {
+  valid: [
+    `export const mapStateToProps = (state, ownProps) => ({
+      myData: getMyData(state, ownProps.myProp),
+    });
+
+    export class MyComponent extends Component {
+      render() {
+        return <div>{this.props.myData}</div>;
+      }
+    }
+
+    MyComponent.propTypes = {
+      myProp: PropTypes.string.isRequired
+    };
+
+    export default connect(mapStateToProps)(MyComponent);`,
+  ],
+  invalid: [{
+    code: `export const mapStateToProps = (state) => ({
+      myData: getMyData(state),
+    });
+
+    export class MyComponent extends Component {
+      render() {
+        return <div>{this.props.myData}</div>;
+      }
+    }
+
+    MyComponent.propTypes = {
+      myProp: PropTypes.string.isRequired
+    };
+
+    export default connect(mapStateToProps)(MyComponent);`,
+
+    errors: [
+      {
+        message: '\'myProp\' PropType is defined but prop is never used',
+      },
+    ],
+  }],
+});


### PR DESCRIPTION
WIP for #28 .
Currently it would filter out all eslint-plugin-react `no-unused-prop-types` errors for a component if `mapStateToProps` or `mapDispatchToProps` merely has a second argument (ie `ownProps`).
I need to add `mergeProps` check and also more granular distinction upon which ownProps are actually being used in redux context.

Will update soon. 
