### PR TITLE
fix: experimental rest property in no-unused-prop-types

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -66,7 +66,14 @@ const propsUsedInRedux = function (context) {
       const usedInReactRedux = context.getAncestors()
         .some(ancestor => belongsToReduxReact(ancestor, null, node));
       if (usedInReactRedux) {
-        node.properties.forEach(prop => context.report(node, `exclude:${prop.key.name}`));
+        node.properties.forEach((prop) => {
+          if (prop.type === 'Property' && prop.key && prop.key.name) {
+            return context.report(node, `exclude:${prop.key.name}`);
+          } else if (prop.type === 'ExperimentalRestProperty' && prop.argument && prop.argument.name) {
+            return context.report(node, `exclude:${prop.argument.name}`);
+          }
+          return undefined;
+        });
       }
     },
   };

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -97,6 +97,41 @@ ruleTester.run('no-unused-prop-types', rule, {
     };
 
     export default connect(mapStateToProps)(MyComponent);`,
+    `const selectorFoo = (state) => ({isFetching: false, name: 'Foo', isDeleting: false, deltedId: ''});
+    const selectorBar = (state) => ({ isFetching: false, name: 'Bar'});
+    export const mapStateToProps = (state) => {
+      const { isFetching: isFetchingFoo, ...restFoo } = selectorFoo(state);
+      const { isFetching: isFeatchingBar, ...restBar } = selectorBar(state);
+      return {
+        isFetchingFoo,
+        isFetchingBar,
+        ...restFoo,
+        ...restBar,
+      };
+    };
+      export class MyComponent extends Component {
+      render() {
+          const {isFetchingFoo, name, isFetchingBar, isDeleting, deletedId} = this.props;
+          return (
+            <div>
+              <span>{isFetchingFoo}</span>
+              <span>{isDeleting}</span>
+              <span>{isFetchingBar}</span>
+              <span>{name}{deletedId}</span>
+            </div>
+          )
+      }
+    };
+
+    MyComponent.propTypes = {
+      isFetchingFoo: PropTypes.bool.isRequired,
+      isDeleting: PropTypes.bool.isRequired,
+      deletedId: PropTypes.number.isRequired,
+      name: Proptypes.string.isRequired,
+      isFetchingBar: PropTypes.bool.isRequired,
+    };
+
+    export default connect(mapStateToProps)(MyComponent);`,
   ],
   invalid: [{
     code: `export const mapStateToProps = (state) => ({


### PR DESCRIPTION
Extends `no-unused-prop-types` rule to handle use case where an `ObjectPattern` properties includes a `ExperimentalRestProperty`.

The `name` property is found inside of `argument` when the property type is `ExperimentalRestProperty`, therefore, you need to handle that use case when calling `context.report`.

Resolves: https://github.com/DianaSuvorova/eslint-plugin-react-redux/issues/43
