### PR TITLE
Bump eslint-plugin-react dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "semantic-release": "^12.4.1"
   },
   "peerDependencies": {
-    "eslint-plugin-react": "^7.11.1"
+    "eslint-plugin-react": "^7.16.0"
   },
   "engines": {
     "node": ">=6.10.0"
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "eslint-rule-composer": "^0.3.0",
-    "eslint-plugin-react": "^7.11.1"
+    "eslint-plugin-react": "^7.16.0"
   }
 }


### PR DESCRIPTION
This eliminates a warning when using eslint 6