### PR TITLE
Include plugin in configs

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = {
   rules,
   configs: {
     recommended: {
+      plugins: ['react-redux'],
       rules: {
         'react-redux/connect-prefer-minimum-two-arguments': 0,
         'react-redux/connect-prefer-named-arguments': 2,
@@ -43,6 +44,7 @@ module.exports = {
       },
     },
     all: {
+      plugins: ['react-redux'],
       rules: activeRulesConfig,
     },
   },

--- a/tests/index.js
+++ b/tests/index.js
@@ -22,6 +22,7 @@ describe('all rule files should be exported by the plugin', () => {
 describe('configurations', () => {
   it('should export a \'recommended\' configuration', () => {
     assert(plugin.configs.recommended);
+    assert(plugin.configs.recommended.plugins.includes('react-redux'));
     Object.keys(plugin.configs.recommended.rules).forEach((configName) => {
       assert.equal(configName.indexOf('react-redux/'), 0);
       const ruleName = configName.substring('react-redux/'.length);
@@ -30,6 +31,7 @@ describe('configurations', () => {
   });
   it('should export a \'all\' configuration', () => {
     assert(plugin.configs.all);
+    assert(plugin.configs.all.plugins.includes('react-redux'));
     Object.keys(plugin.configs.all.rules).forEach((configName) => {
       assert.equal(configName.indexOf('react-redux/'), 0);
       assert.equal(plugin.configs.all.rules[configName], 2);


### PR DESCRIPTION
This adds `plugins: ['react-redux']` to both the `recommended` and `all` configs, and includes tests for each.

Fixes #55