### PR TITLE
Improve mapDispatchToProps-prefer-shorthand text + examples

### DIFF
--- a/docs/rules/mapDispatchToProps-prefer-shorthand.md
+++ b/docs/rules/mapDispatchToProps-prefer-shorthand.md
@@ -1,20 +1,18 @@
 #  Enforces that mapDispatchToProps uses a shorthand method to wrap actions in dispatch calls whenever possible. (react-redux/mapDispatchToProps-prefer-shorthand)
 
->[mapDispatchToProps(dispatch, [ownProps]): dispatchProps] (Object or Function): If an object is passed, each function inside it is assumed to be a Redux action creator. An object with the same function names, but with every action creator wrapped into a dispatch call so they may be invoked directly, will be merged into the component’s props.
+>...`connect` supports an “object shorthand” form for the `mapDispatchToProps` argument: if you pass an object full of action creators instead of a function, `connect` will automatically call bindActionCreators for you internally. We recommend always using the “object shorthand” form of `mapDispatchToProps`, unless you have a specific reason to customize the dispatching behavior.
 
-[source](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options)
+[source](https://github.com/reduxjs/react-redux/blob/master/docs/using-react-redux/connect-dispatching-actions-with-mapDispatchToProps.md#defining-mapdispatchtoprops-as-an-object)
 
 ## Rule details
 
-The following pattern is considered incorrect:
+The following patterns are considered incorrect:
 
 ```js
 const mapDispatchToProps = (dispatch) => ({
   action: () => dispatch(action())
 })
-
-// it should use equivalent shorthand wrapping instead:
-// const mapDispatchToProps = {action}
+export default connect(null, mapDispatchToProps)(Component)
 ```
 
 ```js
@@ -22,19 +20,26 @@ const mapDispatchToProps = (dispatch) => ({
   action: () => dispatch(action()),
   action1: (arg1, arg2) => dispatch(action(arg1, arg2))
 })
+export default connect(null, mapDispatchToProps)(Component)
 ```
 
 The following patterns are considered correct:
 
 
 ```js
-const mapDispatchToProps = {action}
+export default connect(null, { action })(Component)
+```
+
+```js
+const mapDispatchToProps = { action }
+export default connect(null, mapDispatchToProps)(Component)
 ```
 
 ```js
 const mapDispatchToProps = (dispatch) => ({
   action: () => dispatch(actionHelper(true))
 })
+export default connect(null, mapDispatchToProps)(Component)
 ```
 
 ```js
@@ -42,4 +47,5 @@ const mapDispatchToProps = (dispatch) => ({
   action: () => dispatch(action()),
   action1: (arg1, arg2) => dispatch(action(arg1 + arg2))
 })
+export default connect(null, mapDispatchToProps)(Component)
 ```


### PR DESCRIPTION
The examples needed a couple of wording updates to assist developers.
The docs link + extract was out of date too.