### PR TITLE
fix: add prepublishOnly to run build before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "npm run lint && mocha --compilers js:babel-register tests --recursive",
     "semantic-release": "semantic-release",
     "commitmsg": "npm run test && commitlint -e $GIT_PARAMS",
-    "build": "rm -fr ./dist && babel ./src --out-dir ./dist --copy-files"
+    "build": "rm -fr ./dist && babel ./src --out-dir ./dist --copy-files",
+    "prepublishOnly": "npm run test && npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "semantic-release": "semantic-release",
     "commitmsg": "npm run test && commitlint -e $GIT_PARAMS",
     "build": "rm -fr ./dist && babel ./src --out-dir ./dist --copy-files",
-    "prepublishOnly": "npm run test && npm run build"
+    "prepublishOnly": "npm test && npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adding `prepublishOnly` script (as suggested by @ljharb at https://github.com/DianaSuvorova/eslint-plugin-react-redux/issues/80#issuecomment-972606765) to ensure dist folder is present when publishing.

(Should fix the following issues)
Closes #74 #80 