### PR TITLE
fix: fix #104 ReferenceError: context is not defined

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -5,7 +5,7 @@ const isReactReduxConnect = require('../isReactReduxConnect');
 
 const noUnusedPropTypesReact = require('eslint-plugin-react').rules['no-unused-prop-types'];
 
-const belongsToReduxReact = (node, objectName, destrArg) => {
+const belongsToReduxReact = (node, objectName, destrArg, context) => {
   const checkProp = (secondArgument) => {
     const secondArgumentName = secondArgument && secondArgument.type === 'Identifier' && secondArgument.name;
     return (secondArgumentName === objectName // ownProps.myProp
@@ -57,14 +57,14 @@ const propsUsedInRedux = function (context) {
     MemberExpression(node) {
       const nodeName = node.object.name;
       const usedInReactRedux = context.getSourceCode().getAncestors(node)
-        .some(ancestor => belongsToReduxReact(ancestor, nodeName));
+        .some(ancestor => belongsToReduxReact(ancestor, nodeName, null, context));
       if (usedInReactRedux) {
         context.report(node, `exclude:${node.property.name}`);
       }
     },
     ObjectPattern(node) {
       const usedInReactRedux = context.getSourceCode().getAncestors(node)
-        .some(ancestor => belongsToReduxReact(ancestor, null, node));
+        .some(ancestor => belongsToReduxReact(ancestor, null, node, context));
       if (usedInReactRedux) {
         node.properties.forEach((prop) => {
           if (prop.type === 'Property' && prop.key && prop.key.name) {


### PR DESCRIPTION
Hi, fix #104 ReferenceError: context is not defined introduced in #103. The `context` L36 is not undefined in test for some reason. So I've tested in my env.