### PR TITLE
test: lint no-undef

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ module.exports = {
   "rules": {
     "func-names": 0,
     "global-require": 0,
+    "no-undef": "error",
     "prefer-destructuring": 0,
     "strict": 0,
     // Include rules from airbnb configuration directly here
@@ -14,8 +15,12 @@ module.exports = {
   },
   "languageOptions": {
     "globals": {
-      // Define global variables here for your files
-      "mocha": true
+      __dirname: true,
+      console: true,
+      describe: true,
+      it: true,
+      module: true,
+      require: true,
     }
-  }
+  },
 };


### PR DESCRIPTION
Hi,  no-undef rule can test for #104. `context` was Mocha.SuiteFunction in test which is not undef on runtime.